### PR TITLE
fix: make StereoDiffusion optional and resilient to diffusers/transformers version conflicts (transformers 5.x / FLAX_WEIGHTS_NAME)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -26,19 +26,25 @@ except ImportError as e:
     print("  pip install -r requirements.txt")
     print("="*60 + "\n")
 
-# Import StereoDiffusion nodes (optional, requires diffusers)
+# Import StereoDiffusion nodes (optional, requires diffusers + compatible transformers)
 try:
     from .stereodiffusion_nodes import NODE_CLASS_MAPPINGS as DIFFUSION_NODES
     from .stereodiffusion_nodes import NODE_DISPLAY_NAME_MAPPINGS as DIFFUSION_NAMES
     DIFFUSION_AVAILABLE = True
-except ImportError as e:
+except Exception as e:  # Catch ImportError, RuntimeError from lazy diffusers load, etc.
     DIFFUSION_NODES = {}
     DIFFUSION_NAMES = {}
     DIFFUSION_AVAILABLE = False
     print("\n" + "="*60)
-    print("StereoDiffusion dependencies not available. AI stereo generation disabled.")
-    print("To enable StereoDiffusion:")
-    print("  pip install diffusers transformers accelerate einops tqdm scikit-image")
+    print("StereoDiffusion (AI-powered stereo) disabled due to import error.")
+    print(f"  Reason: {type(e).__name__}: {e}")
+    print("This is common with newer transformers versions (>=5.x) + older diffusers.")
+    print("Core depth-based StereoImageNode is unaffected and fully functional.")
+    print("")
+    print("To enable StereoDiffusion (optional):")
+    print("  pip install --upgrade 'diffusers>=0.29' 'transformers<5.0' accelerate einops tqdm scikit-image")
+    print("  or pin compatible versions in your environment.")
+    print("See https://github.com/Dobidop/ComfyStereo/issues for updates.")
     print("="*60 + "\n")
 
 # Combine all node mappings

--- a/model_loader.py
+++ b/model_loader.py
@@ -6,7 +6,30 @@ Functions for loading Stable Diffusion models from HuggingFace or local paths.
 
 import os
 import torch
-from diffusers import StableDiffusionPipeline, StableDiffusionInpaintPipeline, DDIMScheduler, EulerDiscreteScheduler
+
+# Lazy imports for diffusers to avoid hard failures on incompatible versions
+# (e.g. transformers >=5.x removed FLAX_WEIGHTS_NAME that older diffusers expect).
+# These are only needed for the optional StereoDiffusion feature.
+_diffusers = None
+
+
+def _get_diffusers():
+    """Lazily import diffusers components."""
+    global _diffusers
+    if _diffusers is None:
+        from diffusers import (
+            StableDiffusionPipeline,
+            StableDiffusionInpaintPipeline,
+            DDIMScheduler,
+            EulerDiscreteScheduler,
+        )
+        _diffusers = {
+            "StableDiffusionPipeline": StableDiffusionPipeline,
+            "StableDiffusionInpaintPipeline": StableDiffusionInpaintPipeline,
+            "DDIMScheduler": DDIMScheduler,
+            "EulerDiscreteScheduler": EulerDiscreteScheduler,
+        }
+    return _diffusers
 
 
 # Global model cache
@@ -40,6 +63,11 @@ def load_sd_model(model_id_or_path: str = "runwayml/stable-diffusion-v1-5", devi
     cache_key = f"{model_id_or_path}:{scheduler_type}"
     if cache_key in _model_cache:
         return _model_cache[cache_key]
+
+    d = _get_diffusers()
+    StableDiffusionPipeline = d["StableDiffusionPipeline"]
+    DDIMScheduler = d["DDIMScheduler"]
+    EulerDiscreteScheduler = d["EulerDiscreteScheduler"]
 
     if scheduler_type == "euler":
         scheduler = EulerDiscreteScheduler(
@@ -110,6 +138,9 @@ def load_inpainting_model(model_id_or_path: str = "runwayml/stable-diffusion-inp
     cache_key = f"inpaint:{model_id_or_path}"
     if cache_key in _model_cache:
         return _model_cache[cache_key]
+
+    d = _get_diffusers()
+    StableDiffusionInpaintPipeline = d["StableDiffusionInpaintPipeline"]
 
     is_local = os.path.isdir(model_id_or_path)
     model_dtype = torch.float16 if device != "cpu" else torch.float32

--- a/model_wrappers.py
+++ b/model_wrappers.py
@@ -10,8 +10,23 @@ import torch
 import torch.nn.functional as F
 import numpy as np
 from PIL import Image
-from diffusers import DDIMScheduler, EulerDiscreteScheduler, PNDMScheduler
 from tqdm import tqdm
+
+# Lazy import for diffusers schedulers (only needed for ComfyUI model wrapper path in StereoDiffusion)
+_diffusers_schedulers = None
+
+
+def _get_diffusers_schedulers():
+    """Lazily import only the scheduler classes from diffusers."""
+    global _diffusers_schedulers
+    if _diffusers_schedulers is None:
+        from diffusers import DDIMScheduler, EulerDiscreteScheduler, PNDMScheduler
+        _diffusers_schedulers = {
+            "DDIMScheduler": DDIMScheduler,
+            "EulerDiscreteScheduler": EulerDiscreteScheduler,
+            "PNDMScheduler": PNDMScheduler,
+        }
+    return _diffusers_schedulers
 
 # Import functional_call for gradient-enabled forward passes
 # Available in PyTorch 2.0+ as torch.func, fallback to functorch for older versions
@@ -418,15 +433,16 @@ class ComfyUIModelWrapper:
 
     def _create_scheduler(self):
         """Create appropriate scheduler based on detected model type."""
+        sched = _get_diffusers_schedulers()
         if self._model_type == "SD_TURBO":
-            return EulerDiscreteScheduler(
+            return sched["EulerDiscreteScheduler"](
                 beta_start=0.00085,
                 beta_end=0.012,
                 beta_schedule="scaled_linear",
                 timestep_spacing="trailing",
             )
         else:
-            return DDIMScheduler(
+            return sched["DDIMScheduler"](
                 beta_start=0.00085,
                 beta_end=0.012,
                 beta_schedule="scaled_linear",
@@ -442,15 +458,16 @@ class ComfyUIModelWrapper:
             mode: "fast" for EulerDiscreteScheduler (turbo/LCM compatible),
                   "standard" to keep the auto-detected scheduler
         """
+        sched = _get_diffusers_schedulers()
         if mode == "fast":
-            self.scheduler = EulerDiscreteScheduler(
+            self.scheduler = sched["EulerDiscreteScheduler"](
                 beta_start=0.00085,
                 beta_end=0.012,
                 beta_schedule="scaled_linear",
                 timestep_spacing="trailing",
             )
         elif mode == "standard":
-            self.scheduler = DDIMScheduler(
+            self.scheduler = sched["DDIMScheduler"](
                 beta_start=0.00085,
                 beta_end=0.012,
                 beta_schedule="scaled_linear",
@@ -512,7 +529,8 @@ class ComfyUIInpaintRunner:
                 f"(e.g., sd-v1-5-inpainting)."
             )
 
-        self.scheduler = PNDMScheduler(
+        sched = _get_diffusers_schedulers()
+        self.scheduler = sched["PNDMScheduler"](
             beta_start=0.00085,
             beta_end=0.012,
             beta_schedule="scaled_linear",


### PR DESCRIPTION
## Summary
This PR makes the optional StereoDiffusion feature (AI-powered stereo) robust so that loading the ComfyStereo custom node never crashes ComfyUI when there is a version incompatibility between `diffusers` and `transformers`.

### The Problem
Many ComfyUI installations (especially those using recent `transformers>=5.0`) hit this hard error on startup:

```
ImportError: cannot import name 'FLAX_WEIGHTS_NAME' from 'transformers.utils'
...
RuntimeError: Failed to import diffusers.pipelines... because of the above
  File ".../comfystereo/stereodiffusion_nodes.py", line ...
  File ".../comfystereo/model_loader.py", line 9, in <module>
    from diffusers import ...
```

This completely prevents the extension from loading, even though the **core depth-based stereo functionality** (`StereoImageNode`, video SBS conversion, GPU Warp, etc.) does **not** depend on diffusers at all.

### Changes
- **Lazy imports** for diffusers components in:
  - `model_loader.py` (`load_sd_model`, `load_inpainting_model`)
  - `model_wrappers.py` (schedulers used by the ComfyUI model wrapper path)
- **Broader exception handling** in `__init__.py` around the StereoDiffusion import (`except Exception` instead of only `ImportError`) so that runtime errors during lazy loading inside the StereoDiffusion modules are also caught gracefully.
- **Improved diagnostics** in the printed message:
  - Clearly explains that the core stereo image/video nodes are fully functional.
  - Shows the actual error reason.
  - Gives concrete upgrade/pinning advice (`diffusers>=0.29` + `transformers<5.0`).

### Impact
- **Core use case unaffected and always available**: RGB + depth map → high-quality left/right (SBS) stereo video (the main feature for most users, including the `Video2Stereo.json` example).
- StereoDiffusion (the advanced AI feature) remains available when the user has a compatible diffusers + transformers combination.
- No behavior change for users who already have working diffusers setups.

### Testing
- Verified that the core `GenerateStereo` / `StereoImageNode` path loads even when diffusers is absent or broken.
- The lazy `_get_diffusers()` / `_get_diffusers_schedulers()` pattern ensures heavy imports only happen if/when a user actually tries to use a StereoDiffusion node.

Fixes crashes like the one reported with transformers 5.2.0 + diffusers 0.33.1.